### PR TITLE
Potential fix for code scanning alert no. 8: Prototype-polluting assignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -428,6 +428,8 @@ app.put("/template/:id", async (req, res) => {
     if (!req.params.id || !templates[req.params.id]) return res.sendStatus(400);
     const manager = templates[req.params.id];
     for (const i of Object.keys(req.body)) {
+        // Prevent prototype pollution
+        if (i === "__proto__" || i === "constructor" || i === "prototype") continue;
         if (i === "running") {
             if (req.body.running && !manager.running) {
                 try {


### PR DESCRIPTION
Potential fix for [https://github.com/kyokusakin/wplacer/security/code-scanning/8](https://github.com/kyokusakin/wplacer/security/code-scanning/8)

To fix the prototype pollution vulnerability, we should prevent dangerous property names from being assigned to the `manager` object. The best way is to filter out keys that could cause prototype pollution, such as `__proto__`, `constructor`, and `prototype`, before performing the assignment. This can be done by adding a check inside the loop that skips these keys. The change should be made in the `/template/:id` PUT endpoint, specifically in the loop at lines 430–440. No new imports are needed; just add a conditional to skip dangerous keys.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
